### PR TITLE
Allow reseller ACL to be overridden

### DIFF
--- a/CyberPanel.php
+++ b/CyberPanel.php
@@ -99,7 +99,7 @@ class Server_Manager_CyberPanel extends Server_Manager
 
 
         if ($account->getReseller()) {
-            $acl = 'reseller';
+            $acl = $account->getPackage()->getCustomValue('ACL') ?? 'reseller';
         } else {
             $acl = $package->getCustomValue('ACL') ?? 'user';
         }
@@ -303,7 +303,7 @@ class Server_Manager_CyberPanel extends Server_Manager
     private function createUserAccount(Server_Account $account): bool
     {
         if ($account->getReseller()) {
-            $acl = 'reseller';
+            $acl = $account->getPackage()->getCustomValue('ACL') ?? 'reseller';
         } else {
             $acl = $account->getPackage()->getCustomValue('ACL') ?? 'user';
         }


### PR DESCRIPTION
It seems that the default user permissions for "user" and "reseller" are more extensive than necessary. As this is an upstream issue, CyberPanel should consider restricting permissions such as version control for users and resellers. To address this, this PR implements the ability to create a custom Access Control List (ACL) within the theme package.