### PR TITLE
Package change enhancements

### DIFF
--- a/CyberPanel.php
+++ b/CyberPanel.php
@@ -395,8 +395,17 @@ class Server_Manager_CyberPanel extends Server_Manager
      */
     public function changeAccountPackage(Server_Account $account, Server_Package $package): bool
     {
+        /**
+         *
+         * Check and see what the hosting package is. If it doesn't contain the
+         * API user username and is not Default we append it, if it does we just return
+         * the name.
+         */
         if($package->getName() != 'Default') {
             $packageName = $this->_config('username')."_".$package->getName();
+        }
+        if(strtok($package->getName(), '_') == $this->_config('username')) {
+            $packageName = $package->getName();
         }
         else {
             $packageName = $package->getName();


### PR DESCRIPTION
- This now allows you to set the hosting package to $apiuser_hostingPackageName in FOSSBilling.  However, if you do not provide that, and just have hostingPackageName it will append the API user to the hosting package for you eg admin_hostingPackageName